### PR TITLE
$postfix_separator

### DIFF
--- a/src/Currencies/BaseCurrency.php
+++ b/src/Currencies/BaseCurrency.php
@@ -18,12 +18,14 @@ abstract class BaseCurrency
      * Convert value to decimal.
      *
      * @param  float $value
-     * @param  int $decimal_points
+     * @param  int $decimals
+     * @param  string $dec_point
+     * @param  string $thousands_sep
      * @return string
      */
-    public function decimal(float $value, int $decimal_points = 2): string
+    public function decimal(float $value, int $decimals = 2, string $dec_point = '.', string $thousands_sep = ','): string
     {
-        return number_format($value, $decimal_points);
+        return number_format($value, $decimals, $dec_point, $thousands_sep);
     }
 
     /**
@@ -41,16 +43,18 @@ abstract class BaseCurrency
      * Get formatted value.
      *
      * @param  float $value
-     * @param  int|null $decimal_points
+     * @param  int|null $decimals
+     * @param  string|null $dec_point
+     * @param  string|null $thousands_sep
      * @return string
      */
-    public function value(float $value, int $decimal_points = null): string
+    public function value(float $value, int $decimals = null, string $dec_point = null, string $thousands_sep = null): string
     {
-        if (is_null($decimal_points)) {
+        if (is_null($decimals)) {
             return $value;
         }
 
-        return $this->decimal($value, $decimal_points);
+        return $this->decimal($value, $decimals, $dec_point, $thousands_sep);
     }
 
     /**
@@ -58,12 +62,14 @@ abstract class BaseCurrency
      * with currency symbol.
      *
      * @param  float $value
-     * @param  int|null $decimal_points
+     * @param  int|null $decimals
+     * @param  string|null $dec_point
+     * @param  string|null $thousands_sep
      * @return string
      */
-    public function prefix(float $value, int $decimal_points = null): string
+    public function prefix(float $value, int $decimals = null, string $dec_point = null, string $thousands_sep = null): string
     {
-        return $this->prefix.$this->value($value, $decimal_points);
+        return $this->prefix.$this->value($value, $decimals, $dec_point, $thousands_sep);
     }
 
     /**
@@ -71,12 +77,14 @@ abstract class BaseCurrency
      * with currency label.
      *
      * @param  float $value
-     * @param  int|null $decimal_points
+     * @param  int|null $decimals
+     * @param  string|null $dec_point
+     * @param  string|null $thousands_sep
      * @return string
      */
-    public function postfix(float $value, int $decimal_points = null): string
+    public function postfix(float $value, int $decimals = null, string $dec_point = null, string $thousands_sep = null): string
     {
-        return $this->value($value, $decimal_points).' '.$this->postfix;
+        return $this->value($value, $decimals, $dec_point, $thousands_sep).' '.$this->postfix;
     }
 
     /**
@@ -84,12 +92,14 @@ abstract class BaseCurrency
      * with currency symbol and label.
      *
      * @param  float $value
-     * @param  int|null $decimal_points
+     * @param  int|null $decimals
+     * @param  string|null $dec_point
+     * @param  string|null $thousands_sep
      * @return string
      */
-    public function prefixPostfix(float $value, int $decimal_points = null): string
+    public function prefixPostfix(float $value, int $decimals = null, string $dec_point = null, string $thousands_sep = null): string
     {
-        return $this->prefix.$this->value($value, $decimal_points).' '.$this->postfix;
+        return $this->prefix.$this->value($value, $decimals, $dec_point, $thousands_sep).' '.$this->postfix;
     }
 
     /**

--- a/src/Currencies/BaseCurrency.php
+++ b/src/Currencies/BaseCurrency.php
@@ -15,6 +15,11 @@ abstract class BaseCurrency
     protected $postfix;
 
     /**
+     * @var string
+     */
+    protected $postfix_separator = '';
+
+    /**
      * Convert value to decimal.
      *
      * @param  float $value
@@ -99,7 +104,7 @@ abstract class BaseCurrency
      */
     public function prefixPostfix(float $value, int $decimals = null, string $dec_point = null, string $thousands_sep = null): string
     {
-        return $this->prefix.$this->value($value, $decimals, $dec_point, $thousands_sep).' '.$this->postfix;
+        return $this->prefix.$this->value($value, $decimals, $dec_point, $thousands_sep).$this->postfix_separator.$this->postfix;
     }
 
     /**

--- a/src/Currency.php
+++ b/src/Currency.php
@@ -36,7 +36,7 @@ class Currency
     {
         [$className, $value] = $this->classAndValue($values, $currency);
 
-        return (new $className)->decimal($value, $decimal_points);
+        return (new $className)->decimal($value, $decimals, $dec_point, $thousands_sep);
     }
 
     /**
@@ -67,7 +67,7 @@ class Currency
     {
         [$className, $value] = $this->classAndValue($values, $currency);
 
-        return (new $className)->prefix($value, $decimal_points);
+        return (new $className)->prefix($value, $decimals, $dec_point, $thousands_sep);
     }
 
     /**
@@ -84,7 +84,7 @@ class Currency
     {
         [$className, $value] = $this->classAndValue($values, $currency);
 
-        return (new $className)->postfix($value, $decimal_points);
+        return (new $className)->postfix($value, $decimals, $dec_point, $thousands_sep);
     }
 
     /**
@@ -101,7 +101,7 @@ class Currency
     {
         [$className, $value] = $this->classAndValue($values, $currency);
 
-        return (new $className)->prefixPostfix($value, $decimal_points);
+        return (new $className)->prefixPostfix($value, $decimals, $dec_point, $thousands_sep);
     }
 
     /**

--- a/src/Currency.php
+++ b/src/Currency.php
@@ -27,10 +27,12 @@ class Currency
      *
      * @param  string|array $values
      * @param  string|null $currency
-     * @param  int $decimal_points
+     * @param  int $decimals
+     * @param  string|null $dec_point
+     * @param  string|null $thousands_sep
      * @return string
      */
-    public function decimal($values, string $currency = null, int $decimal_points = 2): string
+    public function decimal($values, string $currency = null, int $decimals = 2, string $dec_point = null, string $thousands_sep = null): string
     {
         [$className, $value] = $this->classAndValue($values, $currency);
 
@@ -56,10 +58,12 @@ class Currency
      *
      * @param  string|array $values
      * @param  string|null $currency
-     * @param  int|null $decimal_points
+     * @param  int|null $decimals
+     * @param  string|null $dec_point
+     * @param  string|null $thousands_sep
      * @return string
      */
-    public function withPrefix($values, string $currency = null, int $decimal_points = null): string
+    public function withPrefix($values, string $currency = null, int $decimals = null, string $dec_point = null, string $thousands_sep = null): string
     {
         [$className, $value] = $this->classAndValue($values, $currency);
 
@@ -71,10 +75,12 @@ class Currency
      *
      * @param  string|array $values
      * @param  string|null $currency
-     * @param  int|null $decimal_points
+     * @param  int|null $decimals
+     * @param  string|null $dec_point
+     * @param  string|null $thousands_sep
      * @return string
      */
-    public function withPostfix($values, string $currency = null, int $decimal_points = null): string
+    public function withPostfix($values, string $currency = null, int $decimals = null, string $dec_point = null, string $thousands_sep = null): string
     {
         [$className, $value] = $this->classAndValue($values, $currency);
 
@@ -86,10 +92,12 @@ class Currency
      *
      * @param  string|array $values
      * @param  string|null $currency
-     * @param  int|null $decimal_points
+     * @param  int|null $decimals
+     * @param  string|null $dec_point
+     * @param  string|null $thousands_sep
      * @return string
      */
-    public function withPrefixAndPostfix($values, string $currency = null, int $decimal_points = null): string
+    public function withPrefixAndPostfix($values, string $currency = null, int $decimals = null, string $dec_point = null, string $thousands_sep = null): string
     {
         [$className, $value] = $this->classAndValue($values, $currency);
 


### PR DESCRIPTION
In some countries, like France, the currency symbol is set as postfix (e.g. 1€). 
To get that, I created a new EUR class with $prefix = '' and $postfix = '€' but the result is 1 € (with a space between value and symbol.
To avoid that, I introduced $postfix_separator with a space as default value and I just override it in my EUR class to remove the space.