### PR TITLE
Laravel 10

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -3,11 +3,11 @@
     "description": "Currency component for Laravel 9+",
     "require": {
         "php": "^8.0",
-        "illuminate/http": "^9.0",
-        "illuminate/support": "^9.0"
+        "illuminate/http": "^9.0||^10.0",
+        "illuminate/support": "^9.0||^10.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "^9.0",
+        "phpunit/phpunit": "^10.0",
         "mockery/mockery": "^1.4"
     },
     "license": "MIT",

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,21 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit backupGlobals="false"
-         backupStaticAttributes="false"
-         bootstrap="vendor/autoload.php"
-         colors="true"
-         convertErrorsToExceptions="true"
-         convertNoticesToExceptions="true"
-         convertWarningsToExceptions="true"
-         processIsolation="false"
-         stopOnFailure="true">
-    <testsuites>
-        <testsuite name="Application Test Suite">
-            <directory>./tests/</directory>
-        </testsuite>
-    </testsuites>
-    <filter>
-        <whitelist>
-            <directory suffix=".php">app/</directory>
-        </whitelist>
-    </filter>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" backupGlobals="false" bootstrap="vendor/autoload.php" colors="true" processIsolation="false" stopOnFailure="true" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.3/phpunit.xsd" cacheDirectory=".phpunit.cache" backupStaticProperties="false">
+  <coverage/>
+  <testsuites>
+    <testsuite name="Application Test Suite">
+      <directory>./tests/</directory>
+    </testsuite>
+  </testsuites>
+  <source>
+    <include>
+      <directory suffix=".php">app/</directory>
+    </include>
+  </source>
 </phpunit>


### PR DESCRIPTION
And PHPUnit 10

Just updated the dependencies to work with L9 or 10. 

Ran tests in both cases and with PHPUnit 10 and it all passed.

For PHPUnit 10 this also involves a config migration.